### PR TITLE
fix: remove S3 prefix validation check

### DIFF
--- a/setup-wizard.py
+++ b/setup-wizard.py
@@ -53,11 +53,6 @@ questions = [
 
 answer = prompt(questions)
 
-if not answer["S3-prefix"].startswith("s3://"):
-    breakpoint()
-    raise ValueError("Error: given S3 prefix does not start with s3://")
-
-
 with open(secrets_path, "w") as secrets:
     print(f"export SNAKEMAKE_STORAGE_S3_ACCESS_KEY={answer['S3-access-key']}", file=secrets)
     print(f"export SNAKEMAKE_STORAGE_S3_SECRET_KEY={answer['S3-secret-key']}", file=secrets)


### PR DESCRIPTION
The s3 prefix is not queried anymore and there for must not be validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Setup Wizard: Relaxed S3 prefix input rules. The wizard no longer enforces the "s3://" prefix format during entry, reducing friction for users with alternate or pre-formatted values.
  - The setup flow now continues to save credentials and update your profile even if the S3 prefix doesn’t match the previous pattern, avoiding interruptions during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->